### PR TITLE
Update Pipfile.lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -23,6 +23,7 @@
         },
         "cffi": {
             "hashes": [
+                "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c",
                 "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
                 "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
                 "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
@@ -56,7 +57,7 @@
                 "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
                 "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
             ],
-            "version": "==1.11.5"
+            "version": "==1.14.5"
         },
         "cryptography": {
             "hashes": [


### PR DESCRIPTION
In it's original state this won't compile cffi on Python3.  Older versions of cffi don't seem to have any error handling in compilation for PyInterpreterState.  I've updated the Pipfile.lock with the working version and correct SHA256 which allows pipenv sync to download and build all dependencies, and ultimately run.